### PR TITLE
Allow custom post types

### DIFF
--- a/featured-image-caption.php
+++ b/featured-image-caption.php
@@ -48,7 +48,7 @@ class cc_featured_image_caption {
 	 */
 	function metabox() {
 		// Specify the screens where the meta box should be available
-		$screens = array( 'post', 'page' );
+		$screens = apply_filters('cc_featured_image_caption_screens', array( 'post', 'page' ) );
 
 		// Iterate through the specified screens to add the meta box
 		foreach ( $screens as $screen ) {


### PR DESCRIPTION
Use `apply_filter` on array of post types the metabox is added to.

This allows other plugin/theme developers to add custom post types to the array of post types that get the metabox, for example:

```php
add_filter('cc_featured_image_caption_screens', function($types) {
    $types[] = 'activity';
    return $types;
});
```