### PR TITLE
Allow HTML tags in caption and source text.

### DIFF
--- a/admin/featured-image-caption-admin.php
+++ b/admin/featured-image-caption-admin.php
@@ -116,7 +116,7 @@ class Admin extends FeaturedImageCaption
         // Sanitize the caption
         $caption = array(
             'caption_text'    => wp_kses_post($_POST[self::PREFIX.'caption_text']),
-            'source_text'    => esc_attr(sanitize_text_field($_POST[self::PREFIX.'source_text'])),
+            'source_text'    => wp_kses_post($_POST[self::PREFIX.'source_text']),
             'source_url'    => esc_url($_POST[self::PREFIX.'source_url']),
             'new_window'    => (! empty($_POST[self::PREFIX.'new_window']) ? true : false),
         );

--- a/admin/featured-image-caption-admin.php
+++ b/admin/featured-image-caption-admin.php
@@ -115,7 +115,7 @@ class Admin extends FeaturedImageCaption
         // Now that we've validated nonce and permissions, let's save the caption data
         // Sanitize the caption
         $caption = array(
-            'caption_text'    => esc_attr(wp_kses_post($_POST[self::PREFIX.'caption_text'])),
+            'caption_text'    => wp_kses_post($_POST[self::PREFIX.'caption_text']),
             'source_text'    => esc_attr(sanitize_text_field($_POST[self::PREFIX.'source_text'])),
             'source_url'    => esc_url($_POST[self::PREFIX.'source_url']),
             'new_window'    => (! empty($_POST[self::PREFIX.'new_window']) ? true : false),


### PR DESCRIPTION
Removes the filters and restrictions on HTML tags in caption and source text. HTML tags are still run through `wp_kses_post()` so that only permitted HTML tags are retained.