### PR TITLE
Plugin constants

### DIFF
--- a/classes/Caption.php
+++ b/classes/Caption.php
@@ -19,7 +19,7 @@ class Caption {
      */
     public function __construct() {
         // Get plugin options
-        $this->options = get_option( CCFAC_PREFIX.'options' );
+        $this->options = get_option( CCFIC_PREFIX.'options' );
     }
 
     /**
@@ -62,7 +62,7 @@ class Caption {
     private function caption_data($id)
     {
         // Get the caption data from the post meta
-        $caption = get_post_meta($id, CCFAC_METAPREFIX, true);
+        $caption = get_post_meta($id, CCFIC_METAPREFIX, true);
 
         // If caption data is not present, return false
         if (empty($caption)) {
@@ -101,7 +101,7 @@ class Caption {
         // Initialize the caption HTML
         if (! empty($this->options->container)) {
             // Start with the container <div>
-            $caption = '<div class="'.CCFAC_ID.'">';
+            $caption = '<div class="'.CCFIC_ID.'">';
         } else {
             // Start with an empty string
             $caption = '';
@@ -112,7 +112,7 @@ class Caption {
 
         // Caption text
         if ($shortcode->has_flag('caption-text', $atts) && ! empty($captiondata['caption_text'])) {
-            $caption .= '<span class="'.CCFAC_ID.'-text">'.$captiondata['caption_text'].'</span>';
+            $caption .= '<span class="'.CCFIC_ID.'-text">'.$captiondata['caption_text'].'</span>';
         }
 
         /* Source attribution */
@@ -124,10 +124,10 @@ class Caption {
                 $new_window = ! empty($captiondata['new_window']) ? ' target="_blank"' : '';
 
                 // Source link HTML
-                $caption .= ' <span class="'.CCFAC_ID.'-source"><a href="'.$captiondata['source_url'].'"'.$new_window.'>'.$captiondata['source_text'].'</a></span>';
+                $caption .= ' <span class="'.CCFIC_ID.'-source"><a href="'.$captiondata['source_url'].'"'.$new_window.'>'.$captiondata['source_text'].'</a></span>';
             } elseif ($shortcode->has_flag('source-text', $atts)) {
                 // Caption text, no link
-                $caption .= ' <span class="'.CCFAC_ID.'-source">'.$captiondata['source_text'].'</span>';
+                $caption .= ' <span class="'.CCFIC_ID.'-source">'.$captiondata['source_text'].'</span>';
             }
         }
 

--- a/classes/Hooks.php
+++ b/classes/Hooks.php
@@ -45,10 +45,10 @@ class Hooks {
         $manage = new Manage();
 
         // Plugin activation
-        register_activation_hook( CCFAC_PATH, array( $manage, 'activate' ) );
+        register_activation_hook( CCFIC_PATH, array( $manage, 'activate' ) );
 
         // Plugin deactivation
-        register_deactivation_hook( CCFAC_PATH, array( $manage, 'deactivate' ) );
+        register_deactivation_hook( CCFIC_PATH, array( $manage, 'deactivate' ) );
     }
 
     /**

--- a/classes/Loader.php
+++ b/classes/Loader.php
@@ -15,37 +15,44 @@ class Loader {
      * @since 0.7.0
      */
     public function __construct() {
-        /**
-         * Plugin constants.
-         *
-         * @since 0.7.0
-         */
-        // Plugin ID
-        if ( ! defined( 'CCFAC_ID' ) ) {
-            define( 'CCFAC_ID', 'cc-featured-image-caption' );
-        }
-        // Plugin name
-        if ( ! defined( 'CCFAC_NAME' ) ) {
-            define( 'CCFAC_NAME', 'Featured Image Caption' );
-        }
-        // Plugin version
-        if ( ! defined( 'CCFAC_VERSION' ) ) {
-            define( 'CCFAC_VERSION', '0.7.2' );
-        }
-        // Minimum required version of WordPress
-        if ( ! defined( 'CCFAC_WPVER' ) ) {
-            define( 'CCFAC_WPVER', '3.5' );
-        }
-        // Database prefix
-        if ( ! defined( 'CCFAC_PREFIX' ) ) {
-            define( 'CCFAC_PREFIX', 'cc_featured_image_caption_' );
-        }
-        // Post meta database prefix
-        if ( ! defined( 'CCFAC_METAPREFIX' ) ) {
-            define( 'CCFAC_METAPREFIX', '_cc_featured_image_caption' );
-        }
+        // Constants
+        $this->constants();
 
         // Hooks and filters
         new Hooks();
+    }
+
+    /**
+     * Class constructor.
+     *
+     * @internal
+     *
+     * @since 0.7.0
+     */
+    private function constants() {
+        // Plugin ID
+        if ( ! defined( 'CCFIC_ID' ) ) {
+            define( 'CCFIC_ID', 'cc-featured-image-caption' );
+        }
+        // Plugin name
+        if ( ! defined( 'CCFIC_NAME' ) ) {
+            define( 'CCFIC_NAME', 'Featured Image Caption' );
+        }
+        // Plugin version
+        if ( ! defined( 'CCFIC_VERSION' ) ) {
+            define( 'CCFIC_VERSION', '0.7.2' );
+        }
+        // Minimum required version of WordPress
+        if ( ! defined( 'CCFIC_WPVER' ) ) {
+            define( 'CCFIC_WPVER', '3.5' );
+        }
+        // Database prefix
+        if ( ! defined( 'CCFIC_PREFIX' ) ) {
+            define( 'CCFIC_PREFIX', 'cc_featured_image_caption_' );
+        }
+        // Post meta database prefix
+        if ( ! defined( 'CCFIC_METAPREFIX' ) ) {
+            define( 'CCFIC_METAPREFIX', '_cc_featured_image_caption' );
+        }
     }
 }

--- a/classes/Manage.php
+++ b/classes/Manage.php
@@ -27,7 +27,7 @@ class Manage {
     public function activate()
     {
         // Check to make sure the version of WordPress being used is compatible with the plugin
-        if (version_compare(get_bloginfo('version'), CCFAC_WPVER, '<')) {
+        if (version_compare(get_bloginfo('version'), CCFIC_WPVER, '<')) {
             wp_die('Your version of WordPress is too old to use this plugin. Please upgrade to the latest version of WordPress.');
         }
 
@@ -38,12 +38,12 @@ class Manage {
 
         // Default plugin options
         $options = new \stdClass();
-        $options->version = CCFAC_VERSION; // Current plugin version
+        $options->version = CCFIC_VERSION; // Current plugin version
         $options->auto_append = true; // Automatically append caption to featured image
         $options->container = true; // Wrap the caption HTML in a container div
 
         // Add options to database
-        $result = add_option(CCFAC_PREFIX.'options', $options);
+        $result = add_option(CCFIC_PREFIX.'options', $options);
 
         return $result;
     }
@@ -56,7 +56,7 @@ class Manage {
     public function deactivate()
     {
         // Remove the plugin options from the database
-        $result = delete_option(CCFAC_PREFIX.'options');
+        $result = delete_option(CCFIC_PREFIX.'options');
 
         return $result;
     }
@@ -69,7 +69,7 @@ class Manage {
     private function upgrade()
     {
         // Get the plugin options
-        $options = get_option(CCFAC_PREFIX.'options');
+        $options = get_option(CCFIC_PREFIX.'options');
 
         // If the option does not exist, return
         if ( ! $options ) {
@@ -106,7 +106,7 @@ class Manage {
         the current plugin version number, or whether there is no plugin version
         saved in the database.
         */
-        if (! empty($version) && version_compare($version, CCFAC_VERSION, '<')) {
+        if (! empty($version) && version_compare($version, CCFIC_VERSION, '<')) {
             /* === UPGRADE ACTIONS === (oldest to latest) */
 
             // Version 0.5.0
@@ -160,10 +160,10 @@ class Manage {
 
             /* LAST STEPS ALWAYS!!! Update the plugin version saved in the database */
             // Set the value of the plugin version
-            $options->version = CCFAC_VERSION;
+            $options->version = CCFIC_VERSION;
 
             // Save to the database
-            $result = update_option(CCFAC_PREFIX.'options', $options);
+            $result = update_option(CCFIC_PREFIX.'options', $options);
 
             return $result;
         }

--- a/classes/MetaBox.php
+++ b/classes/MetaBox.php
@@ -20,8 +20,8 @@ class MetaBox {
         // Iterate through the specified screens to add the meta box
         foreach ($screens as $screen) {
             add_meta_box(
-                CCFAC_ID, // HTML ID for the meta box
-                CCFAC_NAME, // Title of the meta box displayed to the us
+                CCFIC_ID, // HTML ID for the meta box
+                CCFIC_NAME, // Title of the meta box displayed to the us
                 array($this, 'metabox_callback'), // Callback function for the meta box to display it to the user
                 $screen, // Locations where the meta box should be shown
                 'side' // Location where the meta box should be shown. This one is placed on the side.
@@ -35,10 +35,10 @@ class MetaBox {
     public function metabox_callback($post)
     {
         // Add a nonce field to verify data submissions came from our site
-        wp_nonce_field(CCFAC_ID, CCFAC_PREFIX.'nonce');
+        wp_nonce_field(CCFIC_ID, CCFIC_PREFIX.'nonce');
 
         // Retrieve the current caption as a string, if set
-        $caption = get_post_meta($post->ID, CCFAC_METAPREFIX, true);
+        $caption = get_post_meta($post->ID, CCFIC_METAPREFIX, true);
 
         // If the data is a string, convert it to an array (legacy data support)
         if (is_string($caption)) {
@@ -47,12 +47,12 @@ class MetaBox {
             );
         }
 
-        echo '<label for="'.CCFAC_PREFIX.'caption_text">Caption text</label><textarea style="width: 100%; max-width: 100%;" id="'.CCFAC_PREFIX.'caption_text" name="'.CCFAC_PREFIX.'caption_text">'.(! empty($caption['caption_text']) ? esc_attr($caption['caption_text']) : null).'</textarea>';
+        echo '<label for="'.CCFIC_PREFIX.'caption_text">Caption text</label><textarea style="width: 100%; max-width: 100%;" id="'.CCFIC_PREFIX.'caption_text" name="'.CCFIC_PREFIX.'caption_text">'.(! empty($caption['caption_text']) ? esc_attr($caption['caption_text']) : null).'</textarea>';
         echo '<br><br>';
         echo '<strong>Source Attribution</strong><br>';
-        echo '<label for="'.CCFAC_PREFIX.'source_text">Text</label><input type="text" style="width: 100%;" id="'.CCFAC_PREFIX.'source_text" name="'.CCFAC_PREFIX.'source_text" value="'.(! empty($caption['source_text']) ? esc_attr($caption['source_text']) : null).'">';
-        echo '<label for="'.CCFAC_PREFIX.'source_url">URL</label><input type="text" style="width: 100%;" id="'.CCFAC_PREFIX.'source_url" name="'.CCFAC_PREFIX.'source_url" value="'.(! empty($caption['source_url']) ? $caption['source_url'] : null).'">';
-        echo '<input type="checkbox" name="'.CCFAC_PREFIX.'new_window" value="1"'.($this->new_window_checked($caption) ? ' checked' : null).'><label for="'.CCFAC_PREFIX.'new_window">Open in new window</label>';
+        echo '<label for="'.CCFIC_PREFIX.'source_text">Text</label><input type="text" style="width: 100%;" id="'.CCFIC_PREFIX.'source_text" name="'.CCFIC_PREFIX.'source_text" value="'.(! empty($caption['source_text']) ? esc_attr($caption['source_text']) : null).'">';
+        echo '<label for="'.CCFIC_PREFIX.'source_url">URL</label><input type="text" style="width: 100%;" id="'.CCFIC_PREFIX.'source_url" name="'.CCFIC_PREFIX.'source_url" value="'.(! empty($caption['source_url']) ? $caption['source_url'] : null).'">';
+        echo '<input type="checkbox" name="'.CCFIC_PREFIX.'new_window" value="1"'.($this->new_window_checked($caption) ? ' checked' : null).'><label for="'.CCFIC_PREFIX.'new_window">Open in new window</label>';
     }
 
     /**
@@ -65,7 +65,7 @@ class MetaBox {
         If it wasn't, return the post ID and be on our way.
         */
         // If no nonce was provided or the nonce does not match
-        if (! isset($_POST[CCFAC_PREFIX.'nonce']) || ! wp_verify_nonce($_POST[CCFAC_PREFIX.'nonce'], CCFAC_ID)) {
+        if (! isset($_POST[CCFIC_PREFIX.'nonce']) || ! wp_verify_nonce($_POST[CCFIC_PREFIX.'nonce'], CCFIC_ID)) {
             return $post_id;
         }
 
@@ -86,17 +86,17 @@ class MetaBox {
         // Now that we've validated nonce and permissions, let's save the caption data
         // Sanitize the caption
         $caption = array(
-            'caption_text'    => $_POST[CCFAC_PREFIX.'caption_text'],
-            'source_text'    => $_POST[CCFAC_PREFIX.'source_text'],
-            'source_url'    => esc_url($_POST[CCFAC_PREFIX.'source_url']),
-            'new_window'    => (! empty($_POST[CCFAC_PREFIX.'new_window']) ? true : false),
+            'caption_text'    => $_POST[CCFIC_PREFIX.'caption_text'],
+            'source_text'    => $_POST[CCFIC_PREFIX.'source_text'],
+            'source_url'    => esc_url($_POST[CCFIC_PREFIX.'source_url']),
+            'new_window'    => (! empty($_POST[CCFIC_PREFIX.'new_window']) ? true : false),
         );
 
         // Update the caption meta field
-        update_post_meta($post_id, CCFAC_METAPREFIX, $caption);
+        update_post_meta($post_id, CCFIC_METAPREFIX, $caption);
 
         // Update the user default for the "new window" checkbox
-        update_user_option(get_current_user_id(), CCFAC_PREFIX.'new_window', $caption['new_window']);
+        update_user_option(get_current_user_id(), CCFIC_PREFIX.'new_window', $caption['new_window']);
     }
 
     /**
@@ -118,7 +118,7 @@ class MetaBox {
         }
         // If not set, look for the user option
         else {
-            $new_window = get_user_option(CCFAC_PREFIX.'new_window', get_current_user_id());
+            $new_window = get_user_option(CCFIC_PREFIX.'new_window', get_current_user_id());
 
             if ($new_window) {
                 return true;

--- a/classes/Option.php
+++ b/classes/Option.php
@@ -19,7 +19,7 @@ class Option {
      */
     public function __construct() {
         // Get plugin options
-        $this->options = get_option( CCFAC_PREFIX.'options' );
+        $this->options = get_option( CCFIC_PREFIX.'options' );
     }
 
     /**
@@ -28,10 +28,10 @@ class Option {
     public function create_options_menu()
     {
         add_options_page(
-            CCFAC_NAME, // Page title. This is displayed in the browser title bar.
-            CCFAC_NAME, // Menu title. This is displayed in the Settings submenu.
+            CCFIC_NAME, // Page title. This is displayed in the browser title bar.
+            CCFIC_NAME, // Menu title. This is displayed in the Settings submenu.
             'manage_options', // Capability required to access the options page for this plugin
-            CCFAC_ID, // Menu slug
+            CCFIC_ID, // Menu slug
             array($this, 'options_page') // Function to render the options page
         );
     }
@@ -43,8 +43,8 @@ class Option {
     {
         // Register the plugin options call and the sanitation callback
         register_setting(
-            CCFAC_PREFIX.'options_fields', // The namespace for plugin options fields. This must match settings_fields() used when rendering the form.
-            CCFAC_PREFIX.'options', // The name of the plugin options entry in the database.
+            CCFIC_PREFIX.'options_fields', // The namespace for plugin options fields. This must match settings_fields() used when rendering the form.
+            CCFIC_PREFIX.'options', // The name of the plugin options entry in the database.
             array($this, 'options_validate') // The callback method to validate plugin options
         );
 
@@ -53,7 +53,7 @@ class Option {
             'display', // Name of the section
             'Display', // Title of the section, displayed on the options page
             array($this, 'display_callback'), // Callback method to display plugin options
-            CCFAC_ID // Page ID for the options page
+            CCFIC_ID // Page ID for the options page
         );
 
         // Section for plugin debugging
@@ -61,7 +61,7 @@ class Option {
             'debug',
             'Debug',
             array($this, 'debug_callback'),
-            CCFAC_ID
+            CCFIC_ID
         );
 
         // Automatically add the caption to the featured image
@@ -69,7 +69,7 @@ class Option {
             'auto_append', // Field ID
             'Automatically add the caption to the featured image', // Field title/label, displayed to the user
             array($this, 'auto_append_callback'), // Callback method to display the option field
-            CCFAC_ID, // Page ID for the options page
+            CCFIC_ID, // Page ID for the options page
             'display' // Settings section in which to display the field
         );
 
@@ -78,7 +78,7 @@ class Option {
             'container', // Field ID
             'Add a container &lt;div&gt; to the caption HTML', // Field title/label, displayed to the user
             array($this, 'container_callback'), // Callback method to display the option field
-            CCFAC_ID, // Page ID for the options page
+            CCFIC_ID, // Page ID for the options page
             'display' // Settings section in which to display the field
         );
     }
@@ -104,7 +104,7 @@ class Option {
 
         // Versioning information
         echo '<strong>Version Information</strong><br>';
-        echo 'Plugin: '.CCFAC_VERSION.'<br>';
+        echo 'Plugin: '.CCFIC_VERSION.'<br>';
         echo 'WordPress: '.get_bloginfo('version').'<br>';
         echo 'PHP: '.phpversion().'<br>';
 
@@ -124,7 +124,7 @@ class Option {
     {
         $checked = (! empty($this->options->auto_append)) ? ' checked' : null;
 
-        echo '<input id="'.CCFAC_PREFIX.'options[auto_append]" name="'.CCFAC_PREFIX.'options[auto_append]" type="checkbox"'.$checked.'>';
+        echo '<input id="'.CCFIC_PREFIX.'options[auto_append]" name="'.CCFIC_PREFIX.'options[auto_append]" type="checkbox"'.$checked.'>';
         echo '<p class="description"><strong>Recommended.</strong> Automatically display the caption data you set for the featured image wherever the featured image is displayed. You do not have to make any modifications to your theme files. If you don\'t know what this means or why you wouldn\'t want this enabled, leave it checked.</p>';
     }
 
@@ -135,7 +135,7 @@ class Option {
     {
         $checked = (! empty($this->options->container)) ? ' checked' : null;
 
-        echo '<input id="'.CCFAC_PREFIX.'options[container]" name="'.CCFAC_PREFIX.'options[container]" type="checkbox"'.$checked.'>';
+        echo '<input id="'.CCFIC_PREFIX.'options[container]" name="'.CCFIC_PREFIX.'options[container]" type="checkbox"'.$checked.'>';
         echo '<p class="description"><strong>Recommended.</strong> Put the entire HTML output of the caption information inside a &lt;div&gt; tag, to give you more control over styling the caption. If you do not know what this means, leave it checked.</p>';
     }
 
@@ -152,13 +152,13 @@ class Option {
         <div class="wrap">
             <?php screen_icon();
         ?>
-            <h2><?php echo CCFAC_NAME;
+            <h2><?php echo CCFIC_NAME;
         ?></h2>
 
             <form action="options.php" method="post">
                 <?php
-                settings_fields(CCFAC_PREFIX.'options_fields');
-        do_settings_sections(CCFAC_ID);
+                settings_fields(CCFIC_PREFIX.'options_fields');
+        do_settings_sections(CCFIC_ID);
         submit_button();
         ?>
             </form>
@@ -186,7 +186,7 @@ class Option {
 
             // If the version number is missing, add it
             if ( empty( $options->version ) ) {
-                $options->version = CCFAC_VERSION;
+                $options->version = CCFIC_VERSION;
             }
         }
 

--- a/featured-image-caption.php
+++ b/featured-image-caption.php
@@ -27,8 +27,8 @@ if( version_compare( phpversion(), '5.3', '<' ) ) {
  */
 function cc_featured_image_caption_loader() {
     // Define the path to this file
-    if ( ! defined( 'CCFAC_PATH' ) ) {
-        define( 'CCFAC_PATH', __FILE__ );
+    if ( ! defined( 'CCFIC_PATH' ) ) {
+        define( 'CCFIC_PATH', __FILE__ );
     }
 
     // Composer autoloader


### PR DESCRIPTION
Moves all plugin constant declarations from `Loader::__construct()` to their own method. Changes the constant prefix from `CCFAC` to `CCFIC` to match the plugin name acronym.