### PR TITLE
Fix shortcode

### DIFF
--- a/classes/Bootstrap.php
+++ b/classes/Bootstrap.php
@@ -8,7 +8,7 @@
 
 namespace cconover\FeaturedImageCaption;
 
-class Loader {
+class Bootstrap {
     /**
      * Class constructor.
      *
@@ -40,7 +40,7 @@ class Loader {
         }
         // Plugin version
         if ( ! defined( 'CCFIC_VERSION' ) ) {
-            define( 'CCFIC_VERSION', '0.7.2' );
+            define( 'CCFIC_VERSION', '0.8.0' );
         }
         // Minimum required version of WordPress
         if ( ! defined( 'CCFIC_WPVER' ) ) {

--- a/classes/Caption.php
+++ b/classes/Caption.php
@@ -28,7 +28,7 @@ class Caption {
      * @param bool $html Whether the result should be fully-formed HTML.
      *                   True: create HTML. False: return raw data array.
      *
-     * @return bool|string $caption If successful, returns the requested result. If unsuccessful, returns false.
+     * @return array|null|string If successful, returns the requested result. If unsuccessful, returns null.
      */
     public function caption($html = true)
     {
@@ -59,7 +59,7 @@ class Caption {
      *
      * @return bool|array $caption If successful, the array of caption data. If unsuccessful, return false.
      */
-    private function caption_data($id)
+    public function caption_data($id)
     {
         // Get the caption data from the post meta
         $caption = get_post_meta($id, CCFIC_METAPREFIX, true);
@@ -96,7 +96,7 @@ class Caption {
      *
      * @return string $caption        The fully assembled caption HTML.
      */
-    private function html($captiondata, $atts = array())
+    public function html($captiondata, $atts = array())
     {
         // Initialize the caption HTML
         if (! empty($this->options->container)) {
@@ -147,7 +147,7 @@ class Caption {
      *
      * @return string $caption        The caption plain text.
      */
-    private function plaintext($captiondata, $atts = array())
+    public function plaintext($captiondata, $atts = array())
     {
         // Start with an empty string
         $caption = '';

--- a/classes/Hooks.php
+++ b/classes/Hooks.php
@@ -96,6 +96,9 @@ class Hooks {
         $shortcode = new Shortcode();
 
         // Register the shortcode
+        add_shortcode( 'ccfic', array( $shortcode, 'shortcode' ) );
+
+        // DEPRECATED shortcode because hyphens are to be avoided.
         add_shortcode( 'cc-featured-image-caption', array( $shortcode, 'shortcode' ) );
     }
 

--- a/classes/Shortcode.php
+++ b/classes/Shortcode.php
@@ -29,8 +29,11 @@ class Shortcode {
             $atts
         );
 
+        // Create a new instance of the Caption class
+        $caption = new Caption();
+
         // Get the caption data
-        $captiondata = $this->caption_data( $post->ID );
+        $captiondata = $caption->caption_data( $post->ID );
 
         // Format-specific flags to force format, ordered by presedence
         do {
@@ -50,13 +53,13 @@ class Shortcode {
         // Select the output format
         switch ( $a['format'] ) {
             case 'plaintext':
-                $caption = $this->plaintext( $captiondata, $atts );
+                $output = $caption->plaintext( $captiondata, $atts );
                 break;
             default:
-                $caption = $this->html( $captiondata, $atts );
+                $output = $caption->html( $captiondata, $atts );
         }
 
-        return $caption;
+        return $output;
     }
 
     /**
@@ -75,9 +78,14 @@ class Shortcode {
             unset($atts['format']);
         }
 
-        // If no flags are set and $all is true, return true
-        if ($all && empty($atts)) {
-            return true;
+        // If no flags are set
+        if (empty($atts)) {
+            // If $all is set, which assumes all attributes
+            if ( $all ) {
+                return true;
+            } else {
+                return false;
+            }
         }
 
         // Cycle through all attributes and return true when we find our flag

--- a/featured-image-caption.php
+++ b/featured-image-caption.php
@@ -4,7 +4,7 @@
  * Plugin Name: Featured Image Caption
  * Plugin URI: https://christiaanconover.com/code/wp-featured-image-caption?utm_source=wp-featured-image-caption
  * Description: Set a caption for the featured image of a post that can be displayed on your site.
- * Version: 0.7.2
+ * Version: 0.8.0
  * Author: Christiaan Conover
  * Author URI: https://christiaanconover.com?utm_source=wp-featured-image-caption-author
  * License: GPLv2.
@@ -35,7 +35,7 @@ function cc_featured_image_caption_loader() {
     require_once 'vendor/autoload.php';
 
     // Instantiate the plugin
-    new \cconover\FeaturedImageCaption\Loader();
+    new \cconover\FeaturedImageCaption\Bootstrap();
 }
 add_action('plugins_loaded', 'cc_featured_image_caption_loader');
 
@@ -52,16 +52,15 @@ add_action('plugins_loaded', 'cc_featured_image_caption_loader');
  * @return string The formatted caption.
  */
 function cc_featured_image_caption( $echo = true, $html = true ) {
-    $caption = new \cconover\FeaturedImageCaption\Caption();
+    // Call the caption data using the shortcode
+    $format = $html ? '' : ' format="plaintext"';
+    $caption = do_shortcode( '[ccfic'.$format.']');
 
-    // If the result should be printed to the screen. $echo and $html MUST both be true.
-    if ( ! empty( $echo ) && ! empty( $html ) ) {
-        // If automatic caption appending is disabled
-        if ( ! $caption->auto_append() ) {
-            echo $caption->caption();
-        }
+    // If the result should be printed to the screen.
+    if ( $echo ) {
+        echo $caption;
     } else {
-        return $caption->caption( $html );
+        return $caption;
     }
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://christiaanconover.com/code/wp-featured-image-caption?ref=pl
 Tags: image, caption, featured image
 Requires at least: 3.5
 Tested up to: 4.2.2
-Stable tag: 0.7.2
+Stable tag: 0.8.0
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Fix the shortcode class to call methods properly. Change the name of the shortcode from `cc-featured-image-caption` to `ccfic`, but retain the old shortcode name for legacy support.