### PR TITLE
Fixes activation

### DIFF
--- a/classes/Bootstrap.php
+++ b/classes/Bootstrap.php
@@ -15,44 +15,7 @@ class Bootstrap {
      * @since 0.7.0
      */
     public function __construct() {
-        // Constants
-        $this->constants();
-
         // Hooks and filters
         new Hooks();
-    }
-
-    /**
-     * Class constructor.
-     *
-     * @internal
-     *
-     * @since 0.7.0
-     */
-    private function constants() {
-        // Plugin ID
-        if ( ! defined( 'CCFIC_ID' ) ) {
-            define( 'CCFIC_ID', 'cc-featured-image-caption' );
-        }
-        // Plugin name
-        if ( ! defined( 'CCFIC_NAME' ) ) {
-            define( 'CCFIC_NAME', 'Featured Image Caption' );
-        }
-        // Plugin version
-        if ( ! defined( 'CCFIC_VERSION' ) ) {
-            define( 'CCFIC_VERSION', '0.8.0' );
-        }
-        // Minimum required version of WordPress
-        if ( ! defined( 'CCFIC_WPVER' ) ) {
-            define( 'CCFIC_WPVER', '3.5' );
-        }
-        // Database prefix
-        if ( ! defined( 'CCFIC_PREFIX' ) ) {
-            define( 'CCFIC_PREFIX', 'cc_featured_image_caption_' );
-        }
-        // Post meta database prefix
-        if ( ! defined( 'CCFIC_METAPREFIX' ) ) {
-            define( 'CCFIC_METAPREFIX', '_cc_featured_image_caption' );
-        }
     }
 }

--- a/classes/Caption.php
+++ b/classes/Caption.php
@@ -19,7 +19,7 @@ class Caption {
      */
     public function __construct() {
         // Get plugin options
-        $this->options = get_option( CCFIC_PREFIX.'options' );
+        $this->options = get_option( CCFIC_KEY.'_options' );
     }
 
     /**
@@ -62,7 +62,7 @@ class Caption {
     public function caption_data($id)
     {
         // Get the caption data from the post meta
-        $caption = get_post_meta($id, CCFIC_METAPREFIX, true);
+        $caption = get_post_meta($id, '_'.CCFIC_KEY, true);
 
         // If caption data is not present, return false
         if (empty($caption)) {

--- a/classes/Hooks.php
+++ b/classes/Hooks.php
@@ -44,9 +44,6 @@ class Hooks {
     private function manage() {
         $manage = new Manage();
 
-        // Plugin activation
-        register_activation_hook( CCFIC_PATH, array( $manage, 'activate' ) );
-
         // Plugin deactivation
         register_deactivation_hook( CCFIC_PATH, array( $manage, 'deactivate' ) );
     }

--- a/classes/Manage.php
+++ b/classes/Manage.php
@@ -20,11 +20,12 @@ class Manage {
     }
 
     /**
-     * Plugin activation.
+     * Plugin activation. This method is static because WordPress needs to be able
+     * to access it directly, before the rest of the plugin is loaded.
      *
      * @since 0.7.0
      */
-    public function activate()
+    public static function activate()
     {
         // Check to make sure the version of WordPress being used is compatible with the plugin
         if (version_compare(get_bloginfo('version'), CCFIC_WPVER, '<')) {
@@ -43,7 +44,7 @@ class Manage {
         $options->container = true; // Wrap the caption HTML in a container div
 
         // Add options to database
-        $result = add_option(CCFIC_PREFIX.'options', $options);
+        $result = add_option(CCFIC_KEY.'_options', $options);
 
         return $result;
     }
@@ -56,7 +57,7 @@ class Manage {
     public function deactivate()
     {
         // Remove the plugin options from the database
-        $result = delete_option(CCFIC_PREFIX.'options');
+        $result = delete_option(CCFIC_KEY.'_options');
 
         return $result;
     }
@@ -69,7 +70,7 @@ class Manage {
     private function upgrade()
     {
         // Get the plugin options
-        $options = get_option(CCFIC_PREFIX.'options');
+        $options = get_option(CCFIC_KEY.'_options');
 
         // If the option does not exist, return
         if ( ! $options ) {
@@ -109,7 +110,9 @@ class Manage {
         if (! empty($version) && version_compare($version, CCFIC_VERSION, '<')) {
             /* === UPGRADE ACTIONS === (oldest to latest) */
 
-            // Version 0.5.0
+            /*
+            Version 0.5.0
+            */
             if (version_compare($version, '0.5.0', '<')) {
                 /*
                 Add an option to automatically append caption to the featured
@@ -123,7 +126,9 @@ class Manage {
                 $options['container'] = true;
             }
 
-            // Version 0.7.0
+            /*
+            Version 0.7.0
+            */
             if (version_compare($version, '0.7.0', '<')) {
                 // Convert the stored plugin options from an array to an object
                 if ( is_array( $options ) ) {
@@ -163,7 +168,7 @@ class Manage {
             $options->version = CCFIC_VERSION;
 
             // Save to the database
-            $result = update_option(CCFIC_PREFIX.'options', $options);
+            $result = update_option(CCFIC_KEY.'_options', $options);
 
             return $result;
         }

--- a/classes/MetaBox.php
+++ b/classes/MetaBox.php
@@ -35,10 +35,10 @@ class MetaBox {
     public function metabox_callback($post)
     {
         // Add a nonce field to verify data submissions came from our site
-        wp_nonce_field(CCFIC_ID, CCFIC_PREFIX.'nonce');
+        wp_nonce_field(CCFIC_ID, CCFIC_KEY.'_nonce');
 
         // Retrieve the current caption as a string, if set
-        $caption = get_post_meta($post->ID, CCFIC_METAPREFIX, true);
+        $caption = get_post_meta($post->ID, '_'.CCFIC_KEY, true);
 
         // If the data is a string, convert it to an array (legacy data support)
         if (is_string($caption)) {
@@ -47,12 +47,12 @@ class MetaBox {
             );
         }
 
-        echo '<label for="'.CCFIC_PREFIX.'caption_text">Caption text</label><textarea style="width: 100%; max-width: 100%;" id="'.CCFIC_PREFIX.'caption_text" name="'.CCFIC_PREFIX.'caption_text">'.(! empty($caption['caption_text']) ? esc_attr($caption['caption_text']) : null).'</textarea>';
+        echo '<label for="'.CCFIC_KEY.'_caption_text">Caption text</label><textarea style="width: 100%; max-width: 100%;" id="'.CCFIC_KEY.'_caption_text" name="'.CCFIC_KEY.'_caption_text">'.(! empty($caption['caption_text']) ? esc_attr($caption['caption_text']) : null).'</textarea>';
         echo '<br><br>';
         echo '<strong>Source Attribution</strong><br>';
-        echo '<label for="'.CCFIC_PREFIX.'source_text">Text</label><input type="text" style="width: 100%;" id="'.CCFIC_PREFIX.'source_text" name="'.CCFIC_PREFIX.'source_text" value="'.(! empty($caption['source_text']) ? esc_attr($caption['source_text']) : null).'">';
-        echo '<label for="'.CCFIC_PREFIX.'source_url">URL</label><input type="text" style="width: 100%;" id="'.CCFIC_PREFIX.'source_url" name="'.CCFIC_PREFIX.'source_url" value="'.(! empty($caption['source_url']) ? $caption['source_url'] : null).'">';
-        echo '<input type="checkbox" name="'.CCFIC_PREFIX.'new_window" value="1"'.($this->new_window_checked($caption) ? ' checked' : null).'><label for="'.CCFIC_PREFIX.'new_window">Open in new window</label>';
+        echo '<label for="'.CCFIC_KEY.'_source_text">Text</label><input type="text" style="width: 100%;" id="'.CCFIC_KEY.'_source_text" name="'.CCFIC_KEY.'_source_text" value="'.(! empty($caption['source_text']) ? esc_attr($caption['source_text']) : null).'">';
+        echo '<label for="'.CCFIC_KEY.'_source_url">URL</label><input type="text" style="width: 100%;" id="'.CCFIC_KEY.'_source_url" name="'.CCFIC_KEY.'_source_url" value="'.(! empty($caption['source_url']) ? $caption['source_url'] : null).'">';
+        echo '<input type="checkbox" name="'.CCFIC_KEY.'_new_window" value="1"'.($this->new_window_checked($caption) ? ' checked' : null).'><label for="'.CCFIC_KEY.'_new_window">Open in new window</label>';
     }
 
     /**
@@ -65,7 +65,7 @@ class MetaBox {
         If it wasn't, return the post ID and be on our way.
         */
         // If no nonce was provided or the nonce does not match
-        if (! isset($_POST[CCFIC_PREFIX.'nonce']) || ! wp_verify_nonce($_POST[CCFIC_PREFIX.'nonce'], CCFIC_ID)) {
+        if (! isset($_POST[CCFIC_KEY.'_nonce']) || ! wp_verify_nonce($_POST[CCFIC_KEY.'_nonce'], CCFIC_ID)) {
             return $post_id;
         }
 
@@ -86,17 +86,17 @@ class MetaBox {
         // Now that we've validated nonce and permissions, let's save the caption data
         // Sanitize the caption
         $caption = array(
-            'caption_text'    => $_POST[CCFIC_PREFIX.'caption_text'],
-            'source_text'    => $_POST[CCFIC_PREFIX.'source_text'],
-            'source_url'    => esc_url($_POST[CCFIC_PREFIX.'source_url']),
-            'new_window'    => (! empty($_POST[CCFIC_PREFIX.'new_window']) ? true : false),
+            'caption_text'    => $_POST[CCFIC_KEY.'_caption_text'],
+            'source_text'    => $_POST[CCFIC_KEY.'_source_text'],
+            'source_url'    => esc_url($_POST[CCFIC_KEY.'_source_url']),
+            'new_window'    => (! empty($_POST[CCFIC_KEY.'_new_window']) ? true : false),
         );
 
         // Update the caption meta field
-        update_post_meta($post_id, CCFIC_METAPREFIX, $caption);
+        update_post_meta($post_id, '_'.CCFIC_KEY, $caption);
 
         // Update the user default for the "new window" checkbox
-        update_user_option(get_current_user_id(), CCFIC_PREFIX.'new_window', $caption['new_window']);
+        update_user_option(get_current_user_id(), CCFIC_KEY.'_new_window', $caption['new_window']);
     }
 
     /**
@@ -118,7 +118,7 @@ class MetaBox {
         }
         // If not set, look for the user option
         else {
-            $new_window = get_user_option(CCFIC_PREFIX.'new_window', get_current_user_id());
+            $new_window = get_user_option(CCFIC_KEY.'_new_window', get_current_user_id());
 
             if ($new_window) {
                 return true;

--- a/classes/Option.php
+++ b/classes/Option.php
@@ -19,7 +19,7 @@ class Option {
      */
     public function __construct() {
         // Get plugin options
-        $this->options = get_option( CCFIC_PREFIX.'options' );
+        $this->options = get_option( CCFIC_KEY.'_options' );
     }
 
     /**
@@ -43,8 +43,8 @@ class Option {
     {
         // Register the plugin options call and the sanitation callback
         register_setting(
-            CCFIC_PREFIX.'options_fields', // The namespace for plugin options fields. This must match settings_fields() used when rendering the form.
-            CCFIC_PREFIX.'options', // The name of the plugin options entry in the database.
+            CCFIC_KEY.'_options_fields', // The namespace for plugin options fields. This must match settings_fields() used when rendering the form.
+            CCFIC_KEY.'_options', // The name of the plugin options entry in the database.
             array($this, 'options_validate') // The callback method to validate plugin options
         );
 
@@ -124,7 +124,7 @@ class Option {
     {
         $checked = (! empty($this->options->auto_append)) ? ' checked' : null;
 
-        echo '<input id="'.CCFIC_PREFIX.'options[auto_append]" name="'.CCFIC_PREFIX.'options[auto_append]" type="checkbox"'.$checked.'>';
+        echo '<input id="'.CCFIC_KEY.'_options[auto_append]" name="'.CCFIC_KEY.'_options[auto_append]" type="checkbox"'.$checked.'>';
         echo '<p class="description"><strong>Recommended.</strong> Automatically display the caption data you set for the featured image wherever the featured image is displayed. You do not have to make any modifications to your theme files. If you don\'t know what this means or why you wouldn\'t want this enabled, leave it checked.</p>';
     }
 
@@ -135,7 +135,7 @@ class Option {
     {
         $checked = (! empty($this->options->container)) ? ' checked' : null;
 
-        echo '<input id="'.CCFIC_PREFIX.'options[container]" name="'.CCFIC_PREFIX.'options[container]" type="checkbox"'.$checked.'>';
+        echo '<input id="'.CCFIC_KEY.'_options[container]" name="'.CCFIC_KEY.'_options[container]" type="checkbox"'.$checked.'>';
         echo '<p class="description"><strong>Recommended.</strong> Put the entire HTML output of the caption information inside a &lt;div&gt; tag, to give you more control over styling the caption. If you do not know what this means, leave it checked.</p>';
     }
 
@@ -157,7 +157,7 @@ class Option {
 
             <form action="options.php" method="post">
                 <?php
-                settings_fields(CCFIC_PREFIX.'options_fields');
+                settings_fields(CCFIC_KEY.'_options_fields');
         do_settings_sections(CCFIC_ID);
         submit_button();
         ?>

--- a/featured-image-caption.php
+++ b/featured-image-caption.php
@@ -22,6 +22,21 @@ if( version_compare( phpversion(), '5.3', '<' ) ) {
     return;
 }
 
+/* Define plugin constants */
+define( 'CCFIC_ID', 'cc-featured-image-caption' ); // Plugin ID
+define( 'CCFIC_NAME', 'Featured Image Caption' ); // Plugin name
+define( 'CCFIC_VERSION', '0.8.0' ); // Plugin version
+define( 'CCFIC_WPVER', '3.5' ); // Minimum required version of WordPress
+define( 'CCFIC_KEY', 'cc_featured_image_caption' ); // Database key
+
+
+// Plugin activation
+if( is_admin() ) {
+    require_once 'classes/Manage.php';
+    // Plugin activation
+    register_activation_hook( __FILE__, array( '\cconover\FeaturedImageCaption\Manage', 'activate' ) );
+}
+
 /**
  * Plugin loader hook.
  */


### PR DESCRIPTION
Fixes the activation method to hook WordPress properly. Changes the way the plugin database prefix/key is defined so that only one constant is used.